### PR TITLE
follow API redirects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     helpscout (0.1.0)
       faraday (>= 0.15.4)
+      faraday_middleware (>= 0.14)
       moneta (>= 0.8.1)
       redis (>= 3.3.5)
 
@@ -12,11 +13,13 @@ GEM
     ast (2.4.0)
     coderay (1.1.2)
     diff-lcs (1.3)
-    faraday (0.17.1)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
     jaro_winkler (1.5.4)
     method_source (0.9.2)
-    moneta (1.2.1)
+    moneta (1.4.0)
     multipart-post (2.1.1)
     parallel (1.19.1)
     parser (2.6.5.0)
@@ -27,7 +30,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.1)
     rb-readline (0.5.5)
-    redis (4.1.3)
+    redis (4.2.2)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -64,4 +67,4 @@ DEPENDENCIES
   rubocop (= 0.77.0)
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/helpscout.gemspec
+++ b/helpscout.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'faraday', '>= 0.15.4'
+  spec.add_dependency 'faraday_middleware', '>= 0.14'
   spec.add_dependency 'moneta', '>= 0.8.1'
   spec.add_dependency 'redis', '>= 3.3.5'
 

--- a/lib/helpscout.rb
+++ b/lib/helpscout.rb
@@ -5,6 +5,7 @@ require 'securerandom'
 require 'json'
 require 'moneta'
 require 'faraday'
+require 'faraday_middleware'
 
 require 'helpscout/client'
 require 'helpscout/errors'

--- a/lib/helpscout/api/request.rb
+++ b/lib/helpscout/api/request.rb
@@ -5,7 +5,7 @@ module HelpScout
     module Request
       def request(method, url, params = {}, opts = {})
         # Generate new client
-        client = HelpScout.new_client
+        client = opts[:client] || HelpScout.new_client
         additional_headers = opts[:headers] || {}
         headers = HelpScout::Client::DEFAULT_HEADERS.merge(additional_headers)
 

--- a/lib/helpscout/client.rb
+++ b/lib/helpscout/client.rb
@@ -44,6 +44,7 @@ module HelpScout
       # Faraday.new doesn't seem to pass in the `headers` properly.
       @connection = Faraday::Connection.new(@base_uri, headers: DEFAULT_HEADERS) do |builder|
         builder.use HelpScout::Middleware::TokenAuth
+        builder.use FaradayMiddleware::FollowRedirects
 
         builder.adapter :net_http
       end

--- a/lib/helpscout/response.rb
+++ b/lib/helpscout/response.rb
@@ -36,6 +36,10 @@ module HelpScout
       status >= 200 && status <= 399
     end
 
+    def raw_response
+      @response
+    end
+
     private
 
     def handle_success

--- a/spec/shared/retrievable.rb
+++ b/spec/shared/retrievable.rb
@@ -2,22 +2,22 @@
 
 RSpec.shared_examples_for 'retrievable' do
   let(:stubs) { Faraday::Adapter::Test::Stubs.new }
-  let(:conn) { Faraday.new { |b| b.adapter(:test, stubs) } }
   let(:client) do
     HelpScout::Client.new(
       client_id: 'client-id',
       client_secret: 'client-secret',
       cache: nil,
-      connection: conn
     )
   end
 
   before do
-    allow(Faraday::Connection).to receive(:new).and_return(conn)
+    # Nasty way of injecting the stubs adapter into the connection.
+    client.instance_variable_get(:@connection).builder.adapter(:test, stubs)
+    allow(HelpScout).to receive(:new_client).and_return(client)
   end
 
   it 'returns the resource' do
-    stubs.get('/v2/oauth2/token') do
+    stubs.post('/v2/oauth2/token') do
       [
         200,
         { 'content-type' => 'application/hal+json;charset=UTF-8' },
@@ -39,5 +39,49 @@ RSpec.shared_examples_for 'retrievable' do
     result = outcome.result
     expect(result).to be_a(described_class)
     expect(result.id).to eq(id)
+  end
+
+  it 'follows redirects' do
+    stubs.post('/v2/oauth2/token') do
+      [
+        200,
+        { 'content-type' => 'application/hal+json;charset=UTF-8' },
+        ResponseLoader.load_json('auth_token')
+      ]
+    end
+
+    redirect_id = 12345
+    data = JSON.load(response_body)
+    data['id'] = redirect_id
+    redirect_body = JSON.generate(data)
+
+    stubs.get("/v2/#{described_class.plural}/#{id}") do
+      [
+        301,
+        {
+          'content-type' => 'application/hal+json;charset=UTF-8',
+          'location' => "#{HelpScout::DEFAULT_BASE_URI}/v2/#{described_class.plural}/12345"
+        },
+        ''
+      ]
+    end
+
+
+    stubs.get("/v2/#{described_class.plural}/12345") do
+      [
+        200,
+        {
+          'content-type' => 'application/hal+json;charset=UTF-8'
+        },
+        redirect_body
+      ]
+    end
+
+    outcome = described_class.retrieve(id, {}, client: client)
+    expect(outcome).to be_success
+
+    result = outcome.result
+    expect(result).to be_a(described_class)
+    expect(result.id).to eq(redirect_id)
   end
 end


### PR DESCRIPTION
Use `FaradayMiddleware::FollowRedirects` to follow redirects and update the tests to properly test the middleware.

It is likely the case that some of the other tests don't properly test the connection, but that is a different problem. Also made it simpler to inspect the `Faraday` response object.